### PR TITLE
Remove unused jQuery

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -179,11 +179,6 @@
             <artifactId>bootstrap-icons</artifactId>
             <version>1.13.1</version>
         </dependency>
-        <dependency>
-            <groupId>org.webjars</groupId>
-            <artifactId>jquery</artifactId>
-            <version>4.0.0</version>
-        </dependency>
 
         <!-- If you want to deploy to a war please -->
         <!-- comment ninja-standalone dependency and  -->

--- a/src/main/java/views/layout/defaultLayout.ftl.html
+++ b/src/main/java/views/layout/defaultLayout.ftl.html
@@ -38,7 +38,6 @@
         </main>
 
     </div> <!-- /container -->
-    <script type="text/javascript" src="${contextPath}/assets/webjars/jquery/4.0.0/jquery.js"></script>
     <script type="text/javascript" src="${contextPath}/assets/webjars/bootstrap/5.3.8/js/bootstrap.min.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Remove the `org.webjars:jquery:4.0.0` dependency from `pom.xml`
- Remove the corresponding `<script>` tag from `defaultLayout.ftl.html`

jQuery was loaded on every page but nothing in the templates or JS
actually calls `$()`/`jQuery`. Picked out of the upcoming Quarkus
migration diff as an independent, unrelated cleanup.

## Test plan
- [x] `mvn compile` succeeds
- [x] `grep -ri jquery src/ pom.xml` returns no matches