### PR TITLE
Bump Maven compiler target to Java 17

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,8 +16,7 @@
         <ninja.version>7.0.0</ninja.version>
         <jetty.version>9.4.58.v20250814</jetty.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
+        <maven.compiler.release>17</maven.compiler.release>
     </properties>
 
     <build>


### PR DESCRIPTION
## Summary
- Replace `maven.compiler.source`/`maven.compiler.target` (11) with `maven.compiler.release` (17)

`.java-version` and the Dockerfile already target Java 17, but the
Maven compiler config was still on 11. Picked out of the upcoming
Quarkus migration diff as an independent, unrelated cleanup.

## Test plan
- [x] `mvn compile` succeeds