### PR TITLE
Build Corretto 17 from Amazon Linux 2023 instead of the amazoncorretto image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,33 @@
 # check=error=true
 
 # ===== Tools Stage =====
-FROM amazoncorretto:17-al2023-headless@sha256:c6390520144e4e05cef7235cccb3e0ca298f920e2e869d153dc2006dc2d31355 AS tools
+FROM public.ecr.aws/amazonlinux/amazonlinux:2023.12.20260622.0@sha256:da8159b6af7d20f55f7e5da633dab214c04cac9ea660bb60963b6bca30c8a6a0 AS tools
+
+ARG version=17.0.19.10-1
+ARG package_version=1
+
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+# hadolint ignore=DL3041
+RUN set -eux && \
+    ARCH="$(rpm --query --queryformat='%{ARCH}' rpm)" && \
+    rpm --import file:///etc/pki/rpm-gpg/RPM-GPG-KEY-amazon-linux-2023 && \
+    echo "localpkg_gpgcheck=1" >> /etc/dnf/dnf.conf && \
+    CORRETO_TEMP=$(mktemp -d) && \
+    pushd "${CORRETO_TEMP}" && \
+    RPM_LIST=("java-17-amazon-corretto-headless-$version.amzn2023.${package_version}.${ARCH}.rpm") && \
+    for rpm in "${RPM_LIST[@]}"; do \
+        curl --fail -O "https://corretto.aws/downloads/resources/$(echo $version | tr '-' '.')/${rpm}" && \
+        rpm -K "${CORRETO_TEMP}/${rpm}" | grep -F "${CORRETO_TEMP}/${rpm}: digests signatures OK"; \
+    done && \
+    dnf install -y "${CORRETO_TEMP}"/*.rpm && \
+    popd && \
+    rm -rf "/usr/lib/jvm/java-17-amazon-corretto.${ARCH}/lib/src.zip" && \
+    rm -rf "${CORRETO_TEMP}" && \
+    dnf clean all && \
+    sed -i '/localpkg_gpgcheck=1/d' /etc/dnf/dnf.conf
+
+ENV LANG=C.UTF-8
+ENV JAVA_HOME=/usr/lib/jvm/java-17-amazon-corretto
 
 RUN dnf update -y --security && \
     dnf install -y tar-1.34 gzip-1.12 && \


### PR DESCRIPTION
## Summary
- Replace the `amazoncorretto:17-al2023-headless` base image in the tools stage with an ECR Public dated snapshot of Amazon Linux 2023, and install the Corretto 17 headless RPM directly (equivalent to [corretto-docker's own Dockerfile](https://github.com/corretto/corretto-docker/blob/b8045df4f76b173c45f9499ca5aa5a82c591a993/17/headless/al2023/Dockerfile))
- This decouples our JDK patch cadence from when AWS republishes the `amazoncorretto` image; `dnf update -y --security` (already in the tools stage) now patches directly against a fresh AL2023 snapshot on every build
- Pinned to `public.ecr.aws/amazonlinux/amazonlinux:2023.12.20260622.0` rather than Docker Hub's floating `amazonlinux:2023` tag — Docker Hub's mirror was found to lag ECR Public by 1-2 weeks (see test plan)

## Test plan
- [x] `hadolint Dockerfile` passes
- [x] `docker build .` succeeds
- [x] `java -version` in the built image reports Corretto-17.0.19.10.1
- [x] `trivy image --vuln-type os --severity CRITICAL,HIGH --ignore-unfixed` is clean (0 findings)
- [x] Verified the Docker Hub lag directly: `amazonlinux:2023` on Docker Hub currently resolves to snapshot `2023.12.20260611.0` (openssl-libs `0.4`, vulnerable), while ECR Public's `2023.12.20260622.0` snapshot has openssl-libs `0.5` and python3-pip-wheel `0.20` (both fixed)