### PR TITLE
Migrate from Apache Commons Lang 2 to Commons Lang 3

### DIFF
--- a/src/main/java/controllers/InboxController.java
+++ b/src/main/java/controllers/InboxController.java
@@ -4,7 +4,7 @@ import java.util.List;
 import java.util.Optional;
 
 import org.apache.commons.io.IOUtils;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 import com.google.inject.Inject;
 import com.google.inject.Singleton;

--- a/src/main/java/filters/IPAddressFilter.java
+++ b/src/main/java/filters/IPAddressFilter.java
@@ -1,6 +1,6 @@
 package filters;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.net.util.SubnetUtils;
 import org.slf4j.Logger;
 

--- a/src/main/java/models/Inbox.java
+++ b/src/main/java/models/Inbox.java
@@ -27,7 +27,7 @@ import javax.mail.internet.MimeUtility;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.io.IOUtils;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 
 import com.google.inject.Inject;

--- a/src/main/java/models/Mail.java
+++ b/src/main/java/models/Mail.java
@@ -10,8 +10,8 @@ import java.util.Optional;
 import javax.mail.Address;
 import javax.mail.internet.MimeUtility;
 
-import org.apache.commons.lang.ArrayUtils;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.ArrayUtils;
+import org.apache.commons.lang3.StringUtils;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 


### PR DESCRIPTION
## Summary
- Swap `org.apache.commons.lang.StringUtils`/`ArrayUtils` imports to `org.apache.commons.lang3` in `IPAddressFilter`, `Inbox`, `Mail`, and `InboxController`
- commons-lang 2 is EOL and end of the road; commons-lang3 is already on the compile classpath transitively (via ninja-core), so this is a pure import swap — every method used (`isBlank`/`isNotBlank`/`isEmpty`/`substring`/`indexOf`/`split`/`contains`/`equals`/`defaultIfBlank`/`join`/`EMPTY`, `ArrayUtils.isNotEmpty`) has an identical signature and behavior in v3
- Picked out of the upcoming Quarkus migration diff as an independent, unrelated cleanup

## Test plan
- [x] `mvn compile` succeeds
- [x] `grep -rn 'org.apache.commons.lang\.' src/` returns no matches (only `lang3` remains)
- [x] `mvn test` — succeeds