### PR TITLE
Fix raw endpoint Content-Type typo

### DIFF
--- a/src/main/java/controllers/InboxController.java
+++ b/src/main/java/controllers/InboxController.java
@@ -55,7 +55,7 @@ public class InboxController {
 
     public Result raw(@PathParam("id") String id) throws Exception {
         byte[] data = inbox.getRaw(id);
-        return Results.contentType("text/plan").renderRaw(data);
+        return Results.contentType("text/plain").renderRaw(data);
     }
 
 }


### PR DESCRIPTION
## Summary
- `InboxController#raw` responds with `Content-Type: text/plan` instead of `text/plain` — fix the typo
- Picked out of the upcoming Quarkus migration diff as an independent, unrelated fix

## Test plan
- [x] `mvn compile` succeeds
- [x] `grep -rn 'text/plan' src/` returns no matches