### PR TITLE
Remove unused @JsonIgnore annotations

### DIFF
--- a/src/main/java/models/Attachment.java
+++ b/src/main/java/models/Attachment.java
@@ -3,8 +3,6 @@ package models;
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
-
 public class Attachment {
 
     private int index;
@@ -56,7 +54,6 @@ public class Attachment {
         this.contentType = contentType;
     }
 
-    @JsonIgnore
     public String getFilenameEncoded() throws UnsupportedEncodingException {
         return URLEncoder.encode(this.getFilename(), "UTF-8");
     }

--- a/src/main/java/models/Mail.java
+++ b/src/main/java/models/Mail.java
@@ -13,8 +13,6 @@ import javax.mail.internet.MimeUtility;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.StringUtils;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
-
 public class Mail {
     private String id;
     private String subject;
@@ -161,27 +159,22 @@ public class Mail {
     /**
      * @return the attached
      */
-    @JsonIgnore
     public boolean isAttached() {
         return ArrayUtils.isNotEmpty(getAttachments());
     }
 
-    @JsonIgnore
     public String getToAddressesReadable() {
         return getAddressesReadable(getToAddresses());
     }
 
-    @JsonIgnore
     public String getCcAddressesReadable() {
         return getAddressesReadable(getCcAddresses());
     }
 
-    @JsonIgnore
     public String getBccAddressesReadable() {
         return getAddressesReadable(getBccAddresses());
     }
 
-    @JsonIgnore
     public String getFromAddressesReadable() {
         return getAddressesReadable(getFromAddresses());
     }


### PR DESCRIPTION
## Summary
- Remove `@JsonIgnore` from `Mail` and `Attachment`, and the now-unused Jackson import
- `Mail`/`Attachment` are only ever rendered through Freemarker templates — nothing in the app serializes them to JSON (no `Results.json()`, no `ObjectMapper` usage anywhere), so these annotations were dead code
- Picked out of the upcoming Quarkus migration diff as an independent, unrelated cleanup

## Test plan
- [x] `mvn compile` succeeds
- [x] `grep -rn 'JsonIgnore' src/` returns no matches