### PR TITLE
Remove unused flash messages

### DIFF
--- a/src/main/java/views/layout/defaultLayout.ftl.html
+++ b/src/main/java/views/layout/defaultLayout.ftl.html
@@ -21,18 +21,6 @@
         <#include "header.ftl.html"/>
         <main>
 
-        <#if (flash.error)??>
-            <div class="alert alert-danger">
-                ${flash.error}
-            </div>
-        </#if>
-
-        <#if (flash.success)??>
-            <div class="alert alert-success">
-                ${flash.success}
-            </div>
-        </#if>
-
         <#nested/>
 
         </main>


### PR DESCRIPTION
## Summary
- Remove the `flash.error`/`flash.success` blocks from `defaultLayout.ftl.html`
- Nothing in the Java code ever uses Ninja's `FlashScope` (no `context.getFlashScope()` calls anywhere), so this markup never rendered anything
- Picked out of the upcoming Quarkus migration diff as an independent, unrelated cleanup

## Test plan
- [x] `mvn compile` succeeds
- [x] `grep -rni flash src/` returns no matches
- [x] Ran the app with `mvn ninja:run` and confirmed `/server` (which uses the same layout) renders correctly with no leftover markup