### PR TITLE
Fix NPE when a mail has no Date header

### DIFF
--- a/src/main/java/models/Inbox.java
+++ b/src/main/java/models/Inbox.java
@@ -96,7 +96,8 @@ public class Inbox {
 
     public Mail get(String id) throws IOException, MessagingException {
         Mail mail = new Mail();
-        try (InputStream in = new FileInputStream(new File(directory, id + Mail.EXT))) {
+        File mailFile = new File(directory, id + Mail.EXT);
+        try (InputStream in = new FileInputStream(mailFile)) {
             Session session = Session.getDefaultInstance(new Properties(), null);
             MimeMessage message = new MimeMessage(session, in);
 
@@ -129,7 +130,12 @@ public class Inbox {
             mail.setCcAddresses(message.getRecipients(Message.RecipientType.CC));
             mail.setBccAddresses(message.getRecipients(Message.RecipientType.BCC));
             mail.setFromAddresses(message.getFrom());
-            mail.setSentDate(message.getSentDate());
+            // Fall back to the stored file timestamp for mails without a Date header
+            Date sentDate = message.getSentDate();
+            if (sentDate == null) {
+                sentDate = new Date(mailFile.lastModified());
+            }
+            mail.setSentDate(sentDate);
         }
 
         return mail;


### PR DESCRIPTION
## Summary
- `Inbox#get` set `Mail.sentDate` directly from `message.getSentDate()`, which returns `null` when a mail has no `Date` header
- The inbox listing (`listPrev`/`listNext`) sorts by `getSentDate().compareTo(...)`, so any mail without a Date header threw a `NullPointerException` and broke the whole inbox view (HTTP 500)
- Fall back to the mail file's last-modified timestamp when the header is missing
- Picked out of the upcoming Quarkus migration diff as an independent bug fix

## Test plan
- [x] `mvn compile` succeeds
- [x] Ran the app with `mvn ninja:run`, sent a mail with no `Date` header via SMTP (`:1025`), and confirmed the inbox (`GET /`) returns HTTP 200 and lists the mail — reproduced the NPE/500 first without the fix, confirmed it's gone with it